### PR TITLE
Add heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Gatsby + ButterCMS Starter Project
 
-This Gatsby starter project fully integrates with dynamic sample content from your ButterCMS account, including main menu, pages, blog posts, categories, and tags, all with a beautiful, custom theme with already-implemented search functionality. All of the included sample content is automatically created in your account dashboard when you sign up for a free trial of ButterCMS.
+This Gatsby starter project fully integrates with dynamic sample content from your ButterCMS account, including main menu, pages, blog posts, categories, and tags, and all with a beautiful, custom theme with already-implemented search functionality. All of the included sample content is automatically created in your account dashboard when you sign up for a free trial of ButterCMS.
 
 You can view a [live demo hosted on Vercel](https://gatsbyjs-starter-buttercms-vercel.vercel.app/) or [on Gatsby Cloud](https://gatsbyjsstarterbuttercmsdemo.gatsbyjs.io/), or you can click a button below to deploy your own copy of our starter
 project to the provider of your choice.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms&env=BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=gatsbyjs-starter-buttercms&repo-name=gatsbyjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Gatsby%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fgatsbyjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=gatsbyjs-starter-buttercms) 
-<a href="https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/ButterCMS/gatsbyjs-starter-buttercms" style="margin-left: 20px;"><img src="https://cdn.buttercms.com/aAdkiTHWQTqqANoET7ak" title="gatsby cloud logo" height="33px" alt="Deploy with Gatsby Cloud"></a>
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms&env=BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=gatsbyjs-starter-buttercms&repo-name=gatsbyjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Gatsby%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fgatsbyjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=gatsbyjs-starter-buttercms)
+
+<a href="https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/ButterCMS/gatsbyjs-starter-buttercms"><img src="https://cdn.buttercms.com/aAdkiTHWQTqqANoET7ak" title="gatsby cloud logo" height="33px" alt="Deploy with Gatsby Cloud"></a>
+
+[![Deploy with Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/ButterCMS/gatsbyjs-starter-buttercms&env%5BBUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)
 
 ## 1. Installation
 
@@ -36,19 +39,31 @@ $ npm run develop
 
 Congratulations! Your starter project is now live at [http://localhost:8000/](http://localhost:8000/).
 
-## 4. Deploy on Vercel or Gatsby Cloud
+## 4. Deploy With A Click
 
-Deploy your Gatsby app using Vercel, the creators of Next.js, or with Gatsby Cloud. With a single click, you'll create a copy of our starter project in your Git provider account, instantly deploy it, and institute a full content workflow connected to your ButterCMS account. Smooth.
+Deploy your Gatsby app using Vercel, the creators of Next.js, with Gatsby Cloud, or with Heroku. With a single click, you'll create a copy of our starter project in your Git provider account, instantly deploy it, and institute a full content workflow connected to your ButterCMS account. Smooth.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms&env=BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=gatsbyjs-starter-buttercms&repo-name=gatsbyjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Gatsby%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fgatsbyjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=gatsbyjs-starter-buttercms) 
-<a href="https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/ButterCMS/gatsbyjs-starter-buttercms" style="margin-left: 20px;"><img src="https://cdn.buttercms.com/aAdkiTHWQTqqANoET7ak" title="gatsby cloud logo" height="33px" alt="Deploy with Gatsby Cloud"></a>
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms&env=BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=gatsbyjs-starter-buttercms&repo-name=gatsbyjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Gatsby%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fgatsbyjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=gatsbyjs-starter-buttercms)
+
+<a href="https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/ButterCMS/gatsbyjs-starter-buttercms"><img src="https://cdn.buttercms.com/aAdkiTHWQTqqANoET7ak" title="gatsby cloud logo" height="33px" alt="Deploy with Gatsby Cloud"></a>
+
+[![Deploy with Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/ButterCMS/gatsbyjs-starter-buttercms&env%5BBUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)
 
 ⚠️ **Don't forget to set the BUTTER_CMS_API_KEY environment variable in Gatsby Cloud.**
 
 ### 5. Webhooks
 
-In order for your deployed app to pull in changes to content in your ButterCMS account, you'll need to follow your hosting provider's steps for setting up webhooks. The ButterCMS webhook settings are located at https://buttercms.com/webhooks/. 
+In order for your deployed app to pull in content changes from your ButterCMS account, you'll need to follow your hosting provider's steps for setting up webhooks. The ButterCMS webhook settings are located at https://buttercms.com/webhooks/. 
 
 ### 6. Previewing Draft Changes
 
 By default, your starter project is set up to allow previewing of draft changes saved in your ButterCMS.com account. To disable this functionality, set the following value in your .env file: BUTTER_CMS_PREVIEW=false
+
+Note that if you deployed with heroku and you want to use the iframe previewing ability on the ButterCMS.com website, you'll need to include trailing slashes when specifying your URLS in
+[your ButterCMS.com settings](https://buttercms.com/settings/previews).
+
+```
+mydomain.com/blog/<slug>   <-- Won't work for previewing
+mydomain.com/blog/<slug>/  <-- Will work for previewing.
+```
+

--- a/app.json
+++ b/app.json
@@ -1,0 +1,24 @@
+{
+    "name": "ButterCMS Gatsby.js Starter Project ",
+    "description": "Drop-in proof-of-concept Gatsby.js app, fully integrated with your ButterCMS account.",
+    "repository": "https://github.com/ButterCMS/gatsbyjs-starter-buttercms",
+    "logo": "https://cdn.buttercms.com/R3fbtvoRT2CqEQSmk8hb",
+    "keywords": ["Gatsby.js", "buttercms", "cms", "blog"],
+    "buildpacks": [
+        {
+          "url": "heroku/nodejs"
+        },
+        {
+          "url": "https://github.com/heroku/heroku-buildpack-static"
+        }
+    ],
+    "env": {
+        "BUTTER_CMS_API_KEY": {
+            "description": "The API token of your ButterCMS account",
+            "value": ""
+        }
+    },
+    "scripts": {
+        "build": "gatsby build"
+    }
+} 

--- a/static.json
+++ b/static.json
@@ -1,0 +1,5 @@
+{
+  "root": "public/",
+  "clean_urls": true,
+  "https_only": true
+}


### PR DESCRIPTION
Trello Card: https://trello.com/c/by0cH7rw/1479-add-heroku-deploy-for-gatsby-and-nextjs

**Goal**: Add heroku button to Gatsby.js starter.

**Description**: This is the second of a few different PRs that will be linked to the same trello card, as this information will also need to be added to docs + onboarding for both Gatsby and Next.js, as well as a bugfix for Django.

Note that Gatsby.js is unique thus far, as it requires the usage of heroku-buildpack-static - [https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/deploying-to-heroku/](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/deploying-to-heroku/). Unfortunately, this leaves us with an issue, as our current gatsby paths are all naked URL's (without trailing slashes), and when the iframe preview is requested via heroku's proxy servers, it triggers two redirects - one to http, and then one to https with the trailing slash. This is a known issue that has some PR's out with heroku but has not yet been fixed: [https://github.com/heroku/heroku-buildpack-static/issues/103](https://github.com/heroku/heroku-buildpack-static/issues/103).

As a result, iframe preview in the customer's buttercms.com account will fail if the URL settings in the preview app are set as naked URL's (without trailing slashes).

I consulted with @jakelumetta to see how he wanted to proceed with this, because it is not intuitive for the user to have to add a trailing slash to their URL's in settings when there isn't one in the paths in the app, and for now, we're just going to add a note to readme and update the app with trailing slashes the next time we update the app in general (or heroku-buildpack-static may issue their own fix for this).


Note: To test button's functionality, right click on the button and get the URL it redirects to [https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms%2Ftree%2F1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BBUTTER_CMS_API_KEY%5D=check+https%3A%2F%2Fbuttercms.com%2Fsettings&template=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms](https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms%2Ftree%2F1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BBUTTER_CMS_API_KEY%5D=check+https%3A%2F%2Fbuttercms.com%2Fsettings&template=https%3A%2F%2Fgithub.com%2FButterCMS%2Fgatsbyjs-starter-buttercms) and replace the github repo url with this branch's url: https://github.com/ButterCMS/gatsbyjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs.

This will give you the following link, which will pull from this branch vs master.
[https://heroku.com/deploy?template=https://github.com/ButterCMS/gatsbyjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BBUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings](https://heroku.com/deploy?template=https://github.com/ButterCMS/gatsbyjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BBUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)

 This will launch the URL using this branch instead of main.
 
 [Video Demo]:(https://share.getcloudapp.com/v1ug1rN8)